### PR TITLE
ENG-256: structured error details & traceback logging for failed runs

### DIFF
--- a/docs/plans/ENG-256-logging-exception-handler-plan.md
+++ b/docs/plans/ENG-256-logging-exception-handler-plan.md
@@ -1,0 +1,258 @@
+# ENG-256 Logging and Exception Handler Improvement Plan
+
+## Feature/Issue summary
+
+The current logging and exception handling path does not expose enough information to debug failed assistant, workflow, node, and tool runs. The main failure recorder only persists `str(e)`, so users lose exception type, wrapped cause chain, traceback, component metadata, and invoke context details that are already available in the runtime.
+
+Goal: improve runtime logs, failed events, and trace error attributes so a developer can identify which component failed, why it failed, and what the underlying cause chain was without changing successful execution behavior.
+
+Scope clarification: the code already uses `raise ... from e` throughout, so an *uncaught* exception escaping `assistant.invoke()` still prints Python's full chained traceback. The breakage this plan targets is specifically in the *logged* and *persisted* representations — `logger.error(f"... {e}")` emits no traceback, and failed events store only `str(e)` — which is what developers actually inspect when a run fails inside the framework. The fix must surface the traceback, the cause chain, and the component location in those two paths.
+
+## Current code findings
+
+- Recording is centralized in `grafi/common/decorators/record_base.py`.
+  - `create_async_decorator()` wraps assistant, workflow, node, and tool invokes.
+  - It records invoke events before execution and respond events after success.
+  - On exception it only does `span.set_attribute("error", str(e))` and creates the failed event with `error=str(e)` (`grafi/common/decorators/record_base.py:138-151`).
+  - The same decorator wraps all four layers (tool, node, workflow, assistant) and each `except` block re-raises the failure upward, so one root failure is recorded and logged at every layer it propagates through. Any per-layer traceback logging must therefore be de-duplicated, or it will emit the same stack trace four-plus times and bury the signal.
+- Failed event serialization is also string-only.
+  - `FailedEvent` has `error: Any`, but `to_dict()` serializes only `"error": str(self.error)` (`grafi/common/events/component_base.py:129-141`).
+  - `ComponentFailedEvent.from_dict()` reads only `data["error"]` (`grafi/common/events/component_base.py:290-320`).
+  - Current tests assert the exact current failed-event shape in `tests/events/tool_events/test_tool_failed_event.py:39-87`, `tests/events/node_events/test_node_failed_event.py:51-108`, `tests/events/workflow_events/test_workflow_failed_event.py`, and `tests/events/assistant_events/test_assistant_failed_event.py`.
+- There is already a Grafi exception hierarchy with useful fields.
+  - `GrafiError` stores `message`, `cause`, `invoke_context`, `timestamp`, and `severity`, and has `to_dict()` (`grafi/common/exceptions/base.py:13-57`).
+  - `NodeExecutionError` adds `node_name` (`grafi/common/exceptions/workflow_exceptions.py:18-30`).
+  - `ToolInvocationError` adds `tool_name`; `LLMToolException`, `FunctionCallException`, and `FunctionToolException` add `model`, `function_name`, or `operation` (`grafi/common/exceptions/tool_exceptions.py:12-75`).
+  - `GrafiError.to_dict()` does not currently include subclass fields, exception module, traceback, or recursive cause details.
+- Workflow and tool boundaries wrap exceptions repeatedly.
+  - Tool failures are wrapped in domain exceptions in `FunctionTool.invoke()` (`grafi/tools/functions/function_tool.py:47-68`), `FunctionCallTool.invoke()` (`grafi/tools/function_calls/function_call_tool.py:118-151`), and LLM tool implementations such as `OpenAITool.invoke()` (`grafi/tools/llms/impl/openai_tool.py:102-151`).
+  - Workflow node execution wraps lower-level failures into `NodeExecutionError` in sequential and parallel paths (`grafi/workflows/impl/event_driven_workflow.py:306-312`, `379-384`, `435-440`, `544-553`, `568-573`).
+  - The top-level workflow invoke re-raises `NodeExecutionError` but wraps other errors in `WorkflowError` (`grafi/workflows/impl/event_driven_workflow.py:578-607`).
+  - Each wrap builds its message with an f-string such as `f"Node execution failed: {e}"`, and `GrafiError.__str__` already appends `[Caused by: ...]`, so the persisted `error` string nests redundantly at every layer and becomes hard to read. The structured `cause` chain is the real fix; the flat string is kept only for backward compatibility.
+- Logging is currently direct Loguru usage without a Grafi-specific logging utility.
+  - `loguru` is a dependency in `pyproject.toml`.
+  - Modules import `from loguru import logger` directly, for example `grafi/common/containers/container.py:7` and `grafi/workflows/impl/event_driven_workflow.py`.
+  - There is no package-level `configure_logging()` or structured context helper.
+- Event-store deserialization errors also drop traceback and cause details.
+  - `_create_event_from_dict()` logs only `Failed to create event from dict: {e}` and raises a new `ValueError` without `from e` (`grafi/common/event_stores/event_store.py:67-81`).
+- Tracing docs promise richer failed-event and trace behavior than the implementation provides.
+  - `docs/docs/user-guide/invoke-decorators.md` says decorators capture exception details, add error information to spans, and preserve context, but the code currently records only a string.
+
+## Proposed implementation approach
+
+1. Add a small exception serialization utility.
+   - Add a new module such as `grafi/common/exceptions/serialization.py`.
+   - Define an `ErrorDetails` Pydantic model or typed dict with fields:
+     - `error_type`
+     - `error_module`
+     - `message`
+     - `severity`
+     - `timestamp`
+     - `component_type`
+     - `component_name`
+     - `component_id`
+     - `invoke_context`
+     - domain fields when present: `node_name`, `tool_name`, `model`, `function_name`, `operation`, `topic_name`
+     - `cause`, recursively summarized over a bounded chain (depth cap, e.g. 10) with a cycle guard on already-seen exception ids, so self-referential or very deep `__cause__`/`cause` chains cannot loop or bloat the record
+     - `traceback`, controlled by an option
+   - Provide functions:
+     - `error_to_dict(exc, *, include_traceback: bool = True, max_traceback_frames: int | None = None) -> dict`
+     - `flatten_error_chain(exc) -> list[dict]`
+     - `error_message(exc) -> str`
+     - `has_logged_traceback(exc) -> bool`
+     - `mark_traceback_logged(exc) -> None`
+   - Use existing `GrafiError` fields as the primary source, then fall back to generic exception attributes.
+   - For the cause chain, traverse a single consistent source (prefer `GrafiError.cause`, fall back to `exc.__cause__`, then `exc.__context__`). In this codebase `cause=e` and `raise ... from e` are set together, so they coincide; pick one order and document it.
+   - Keep the returned details strictly JSON-compatible before they are placed in events, since `EventStorePostgres` persists `event_data` as JSONB. Use primitives/lists/dicts only, and sanitize any unexpected values with the same style as the existing `to_jsonable_python` usage in `record_base.py`.
+
+2. Extend `GrafiError.to_dict()` instead of replacing it.
+   - Keep existing keys (`error_type`, `message`, `timestamp`, `severity`, `cause`, `invoke_context`) for compatibility.
+   - Add optional subclass fields for known exception attributes.
+   - Add a non-breaking `cause_details` object or chain list.
+   - Avoid making traceback mandatory in `GrafiError.to_dict()` if that would make deterministic tests harder; traceback can be added by `error_to_dict()` at capture time.
+
+3. Make failed events backward compatible but more useful.
+   - Keep `data["error"]` as the same human-readable string so existing stored events and tests keep a stable field.
+   - Add `data["error_details"]` as an optional structured object.
+   - Update `FailedEvent` in `grafi/common/events/component_base.py` with an optional `error_details: Optional[Dict[str, Any]] = None`.
+   - Update `FailedEvent.to_dict()` to include `error_details` only when present.
+   - Update `ComponentFailedEvent.from_dict()` to read `data["data"].get("error_details")` so old event data still loads.
+   - Keep event type values unchanged.
+
+4. Improve the decorator exception handler.
+   - In `create_async_decorator()` (`grafi/common/decorators/record_base.py`), build structured details once in the `except Exception as e` block.
+     - Build the details (and any `traceback.format_exception(...)` call) from inside the `except` block while the caught exception object is still in scope and its `__traceback__` is available.
+   - Add component metadata from `EventContext` into the structured details.
+   - Record failed events with both `error=str(e)` and `error_details=...`. Failed events are persisted and queried per layer, so recording full details at every layer is fine and useful — the de-duplication below applies only to console/file traceback logging, not to events.
+   - De-duplicate console/file traceback logging across the four stacked decorator layers (tool → node → workflow → assistant) so one root failure does not print the same stack trace four-plus times:
+     - Emit the full `logger.opt(exception=e).error(...)` traceback once, at the layer closest to the failure (the first decorator to catch it — the innermost tool/node layer), which is also the most precise "where the error is".
+     - Mark the exception as already-logged and have outer layers that see the mark log only a concise one-line summary (component name, type, message) instead of repeating the full trace.
+     - The mark cannot be checked only on the current exception object. The workflow creates new wrapper exceptions such as `NodeExecutionError(..., cause=node_error)` after the tool/node decorator has already logged the inner exception. Therefore `has_logged_traceback(exc)` must scan the wrapped cause chain (`GrafiError.cause`, `__cause__`, `__context__`) and return true if any linked exception is marked.
+     - `mark_traceback_logged(exc)` can set a private attribute such as `_grafi_traceback_logged = True`; if a third-party exception does not allow custom attributes, fall back to an internal id-based set for the current process.
+     - When logging a newly-created wrapper exception whose cause chain is already marked, mark the wrapper too. This keeps later assistant/workflow layers concise without relying on repeated cause-chain scans.
+     - The manual `logger.error(f"... {e}")` calls inside `event_driven_workflow.py` (`invoke_parallel`/`_invoke_node`, lines ~371, 434, 545, 566) must use the same helper and cause-chain-aware flag so they do not add further duplicate traces.
+   - Set trace attributes such as:
+     - `error = True`
+     - `error.type`
+     - `error.message`
+     - `error.stack`
+     - `error.details` as JSON when serializable
+   - Use `span.record_exception(e)` and `span.set_status(Status(StatusCode.ERROR, ...))` if the OpenTelemetry span supports it.
+   - Log using Loguru with `logger.bind(...)` and `logger.opt(exception=e).error(...)` so console/file logs include traceback and context, subject to the de-duplication rule above.
+   - Preserve current behavior by re-raising the same exception.
+
+5. Add a small Grafi logging helper.
+   - Add `grafi/common/logging.py` or `grafi/common/logging_utils.py`.
+   - Provide helpers such as:
+     - `bind_invoke_context(logger, invoke_context, **extra)`
+     - `log_exception(exc, *, component_name, component_type, invoke_context, metadata=None)`
+     - optional `configure_logging(level: str | None = None, json: bool = False)` for applications that want standard Loguru setup.
+   - Avoid forcing global `logger.remove()` at import time; library code should not surprise host applications.
+   - Use this helper first in `record_base.py`, and only later migrate scattered direct `logger.error(f"... {e}")` calls if needed.
+
+6. Improve exception chaining where current code loses cause context.
+   - Change `grafi/common/event_stores/event_store.py:79-81` to log with exception details and raise `ValueError(...) from e`.
+   - For workflow log lines such as `logger.error(f"Node {node_name} failed with exception: {result}")`, use exception-aware logging where `result` is an exception object.
+   - Do not remove existing `raise ... from ...` statements; they are important for cause chains.
+   - Point log/event consumers and docs at the structured `error_details.cause` chain for the readable root cause, rather than the flat nested `error` string, which stays only for backward compatibility.
+
+7. Update docs after behavior changes.
+   - Update `docs/docs/user-guide/invoke-decorators.md` to describe `data.error` and optional `data.error_details`.
+   - Add a brief example of configuring Loguru through the new helper if `configure_logging()` is added.
+
+## Files to change
+
+- `grafi/common/exceptions/serialization.py`
+  - New utility for structured exception serialization, cause-chain extraction, and traceback formatting.
+- `grafi/common/exceptions/base.py`
+  - Extend `GrafiError.to_dict()` with optional subclass fields and structured cause details.
+- `grafi/common/events/component_base.py`
+  - Add optional `error_details` to `FailedEvent`.
+  - Serialize `error_details` when present.
+  - Deserialize it with `data["data"].get("error_details")`.
+- `grafi/common/decorators/record_base.py`
+  - Build structured exception details in the centralized async decorator.
+  - Record enhanced failed events.
+  - Add exception-aware Loguru logging and richer span error attributes.
+- `grafi/common/event_stores/event_store.py`
+  - Preserve deserialization cause with `raise ... from e`.
+  - Log event deserialization failures with traceback.
+- `grafi/workflows/impl/event_driven_workflow.py`
+  - Replace string-only `logger.error(...)` calls in node failure paths with exception-aware structured logging, but keep exception types and propagation unchanged.
+- `grafi/common/logging.py` or `grafi/common/logging_utils.py`
+  - New helper module for binding invoke/component context and optional user-facing logging configuration.
+- Tests:
+  - `tests/common/decorators/test_record_decorators.py`
+  - `tests/events/tool_events/test_tool_failed_event.py`
+  - `tests/events/node_events/test_node_failed_event.py`
+  - `tests/events/workflow_events/test_workflow_failed_event.py`
+  - `tests/events/assistant_events/test_assistant_failed_event.py`
+  - Add new tests under `tests/common/exceptions/` for the serialization helper.
+  - Add/update workflow and assistant exception tests in `tests/assistants/test_assistant_mock_llm.py` and/or `tests/workflow/test_event_driven_workflow.py`.
+- Docs:
+  - `docs/docs/user-guide/invoke-decorators.md`
+
+## API/data model changes
+
+- Additive event data change:
+  - Current failed event:
+    ```json
+    {
+      "data": {
+        "input_data": "...",
+        "error": "[ERROR] ..."
+      }
+    }
+    ```
+  - Proposed failed event:
+    ```json
+    {
+      "data": {
+        "input_data": "...",
+        "error": "[ERROR] ...",
+        "error_details": {
+          "error_type": "NodeExecutionError",
+          "error_module": "grafi.common.exceptions.workflow_exceptions",
+          "message": "Async node execution failed: ...",
+          "severity": "ERROR",
+          "node_name": "ErrorNode",
+          "invoke_context": {
+            "conversation_id": "...",
+            "invoke_id": "...",
+            "assistant_request_id": "...",
+            "user_id": "",
+            "kwargs": {}
+          },
+          "cause": {
+            "error_type": "FunctionCallException",
+            "message": "Async function call failed: ..."
+          },
+          "traceback": "Traceback ..."
+        }
+      }
+    }
+    ```
+- No event type enum changes are needed.
+- No public invoke method signatures need to change.
+- Optional new public API if desired:
+  - `grafi.common.logging.configure_logging(...)`
+  - `grafi.common.exceptions.serialization.error_to_dict(...)`
+
+## Implementation sequencing
+
+The intellectual fix is small; most of the line count is structure and test updates. Split the work so the debugging win lands first and the refactor follows independently.
+
+- PR 1 — the actual debugging fix (highest leverage, ships the goal on its own):
+  - Decorator exception handler in `record_base.py`: exception-aware logging with the de-duplication rule (approach step 4), plus `error_details` (error type, module, traceback, bounded cause chain, component metadata, invoke context) on failed events.
+  - Minimal `FailedEvent.error_details` field plus serialize/deserialize so the details persist and old data still loads.
+  - Just enough of the serialization/logging helper (inline or a thin module) to build JSON-compatible `error_details` and enforce cause-chain-aware traceback de-duplication.
+  - Updated failed-event tests for the additive field; one decorator test asserting `error_details` is recorded and the original exception still propagates.
+  - This PR alone makes a failed run debuggable: traceback, component location, and cause chain appear in both logs and persisted events.
+- PR 2 — structure and breadth (no behavior change to the fix):
+  - Extract the full `serialization.py` and `logging_utils.py` helpers; refactor PR 1's inline code onto them.
+  - Extend `GrafiError.to_dict()` with subclass fields and structured cause details.
+  - Fix `event_store.py` `_create_event_from_dict` to `raise ValueError(...) from e` and log with traceback.
+  - Migrate the scattered `logger.error(f"... {e}")` calls in `event_driven_workflow.py` to exception-aware logging that respects the de-duplication flag.
+  - Optional `configure_logging()` opt-in helper, plus the docs updates.
+
+## Testing plan
+
+- Unit test the exception serialization helper.
+  - Generic exception with traceback.
+  - `GrafiError` with `invoke_context`.
+  - `NodeExecutionError` containing a `FunctionCallException` cause.
+  - `LLMToolException` includes `tool_name` and `model`.
+  - `FunctionCallException` includes `function_name`.
+- Update failed-event serialization tests.
+  - Existing tests should still assert `data["error"]`.
+  - Add cases where `error_details` is present and round-trips through `to_dict()` and `from_dict()`.
+  - Add old-data compatibility tests where `error_details` is absent.
+- Add decorator behavior tests.
+  - Trigger an exception through a decorated tool or small dummy component.
+  - Assert the event store receives a failed event with `error_details.error_type`, `message`, component metadata, and invoke context.
+  - Assert the original exception still propagates.
+- Add workflow propagation tests.
+  - Reuse existing failing tool paths from `tests/assistants/test_assistant_mock_llm.py:1618-1743`.
+  - Assert the final `NodeExecutionError` still propagates.
+  - Inspect recorded `ToolFailed`, `NodeFailed`, `WorkflowFailed`, or `AssistantFailed` events and verify structured cause chain contains the original user exception message.
+- Add logging tests with patched Loguru logger only where stable.
+  - Prefer asserting helper behavior over exact Loguru formatting.
+  - Avoid brittle assertions on full traceback text.
+  - Add a de-duplication test where an inner exception is marked as logged, then wrapped in `NodeExecutionError(cause=inner)`, and verify the helper treats the wrapper as already logged.
+- Regression commands:
+  - `uv run pytest tests/common/exceptions tests/common/decorators tests/events -q`
+  - `uv run pytest tests/tools/functions/test_function_tool.py tests/tools/llm_function_calls/test_function_call_tool.py -q`
+  - `uv run pytest tests/assistants/test_assistant_mock_llm.py::TestEdgeCasesAndExceptions -q`
+  - Broader final run: `uv run pytest tests -q`
+
+## Risks, assumptions, and open questions
+
+- Risk: failed-event tests currently assert exact dictionaries. Adding `error_details` unconditionally will require fixture updates. To reduce breakage, include it only when passed and add compatibility tests for old event data.
+- Risk: tracebacks can include local paths and large payloads. The implementation should support disabling traceback capture or limiting frames, probably through environment variables or helper options.
+- Risk: `input_data` may contain user content or tool arguments. The logging helper should avoid logging full inputs by default; failed events already persist input data today, so this plan should not expand logged sensitive payloads beyond current event storage.
+- Risk: Loguru global configuration in a library can interfere with host applications. Keep `configure_logging()` opt-in.
+- Risk: the four stacked decorator layers each catch and re-raise the same failure, so naive `logger.opt(exception=e)` logging emits the same traceback four-plus times (more once the manual workflow `logger.error` calls are made exception-aware), which buries the signal and makes debugging harder rather than easier. Mitigation: log the full traceback once at the layer closest to the failure and mark the exception so outer layers log only a one-line summary (see approach step 4). Full structured `error_details` are still recorded on every layer's failed event.
+- Assumption: the primary requested improvement is for the Grafi library runtime path, not only the integration examples.
+- Assumption: persisted event schemas can accept additive JSON fields because `EventStorePostgres` stores `event_data` as JSONB and in-memory storage keeps event objects.
+- Open question: should `error_details.traceback` be stored in persistent events by default, or only emitted to logs/traces? Recommendation: include it by default in local/dev, make it configurable for production.
+- Open question: should failed events store the complete cause chain for every component level or only the root cause plus immediate wrapper? Recommendation: store a bounded chain to avoid very large event records.

--- a/grafi/common/decorators/record_base.py
+++ b/grafi/common/decorators/record_base.py
@@ -2,6 +2,7 @@
 
 import functools
 import json
+import os
 from dataclasses import dataclass
 from typing import Any
 from typing import AsyncGenerator
@@ -12,6 +13,9 @@ from typing import Type
 from typing import TypeVar
 from typing import Union
 
+from loguru import logger
+from opentelemetry.trace import Status
+from opentelemetry.trace import StatusCode
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic_core import to_jsonable_python
@@ -23,6 +27,9 @@ from grafi.common.events.topic_events.consume_from_topic_event import (
     ConsumeFromTopicEvent,
 )
 from grafi.common.events.topic_events.publish_to_topic_event import PublishToTopicEvent
+from grafi.common.exceptions.serialization import error_message
+from grafi.common.exceptions.serialization import error_to_dict
+from grafi.common.exceptions.serialization import iter_cause_chain
 from grafi.common.models.default_id import default_id
 from grafi.common.models.invoke_context import InvokeContext
 from grafi.common.models.message import Message
@@ -32,6 +39,10 @@ from grafi.workflows.workflow import Workflow
 
 
 T = TypeVar("T")
+
+# Attribute used to mark an exception whose full traceback has already been
+# logged, so the same root failure is not dumped at every decorator layer.
+_TRACEBACK_LOGGED_ATTR = "_grafi_traceback_logged"
 
 
 class EventContext(BaseModel):
@@ -57,6 +68,117 @@ class ComponentConfig:
     ]  # Extracts component-specific metadata
     process_async_result: Callable[[List], Any]
     span_name_suffix: str = "invoke"  # Suffix for span name
+
+
+def _include_traceback() -> bool:
+    """Whether to capture tracebacks into structured error details.
+
+    Enabled by default. Set ``GRAFI_ERROR_INCLUDE_TRACEBACK`` to a falsy value
+    (``0``/``false``/``no``/``off``) to omit tracebacks from persisted events,
+    e.g. in production where they may carry sensitive paths or large payloads.
+    """
+    value = os.getenv("GRAFI_ERROR_INCLUDE_TRACEBACK")
+    if value is None:
+        return True
+    return value.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _build_error_details(exc: Exception, metadata: EventContext) -> Dict[str, Any]:
+    """Build the structured ``error_details`` payload for a failed component."""
+    details = error_to_dict(exc, include_traceback=_include_traceback())
+    # Identify which component failed (the "where"), alongside the exception's
+    # own type/module/cause chain (the "why").
+    details["component_id"] = metadata.id
+    details["component_name"] = metadata.name
+    details["component_type"] = metadata.type
+    return details
+
+
+def _record_span_error(
+    span: Any, exc: Exception, error_details: Dict[str, Any]
+) -> None:
+    """Attach structured error information to the active span."""
+    span.set_attribute("error", str(exc))
+    span.set_attribute("error.type", error_details["error_type"])
+    span.set_attribute("error.message", error_details["message"])
+    traceback_str = error_details.get("traceback")
+    if traceback_str:
+        span.set_attribute("error.stack", traceback_str)
+    try:
+        span.set_attribute(
+            "error.details", json.dumps(error_details, default=to_jsonable_python)
+        )
+    except (TypeError, ValueError):
+        pass
+    try:
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR, error_details["message"]))
+    except Exception:  # pragma: no cover - defensive; span impls vary
+        pass
+
+
+def _traceback_already_logged(exc: Exception) -> bool:
+    """True if any exception in the cause chain has had its traceback logged."""
+    # Scan generously: each decorator layer marks the exception it sees (below),
+    # so the flag is normally within a few links, but a large bound keeps the
+    # invariant robust for deeply nested agent-calling chains. The cycle guard in
+    # iter_cause_chain prevents runaway traversal.
+    return any(
+        getattr(link, _TRACEBACK_LOGGED_ATTR, False)
+        for link in iter_cause_chain(exc, max_depth=1000)
+    )
+
+
+def _log_component_exception(
+    exc: Exception,
+    metadata: EventContext,
+    invoke_context: InvokeContext,
+    error_details: Dict[str, Any],
+) -> None:
+    """Log a failed component, with a full traceback only once.
+
+    The same root failure propagates through the tool -> node -> workflow ->
+    assistant decorators (and is re-wrapped along the way). Logging the full
+    traceback at every layer would print the same stack four-plus times, so the
+    full traceback is emitted once at the layer closest to the failure (the first
+    decorator to catch it); outer layers log a one-line summary instead.
+
+    The traceback is taken from ``error_details`` -- a plain, stdlib-formatted
+    string that does NOT include local-variable values (unlike Loguru's
+    ``opt(exception=...)`` with ``diagnose=True``). This keeps secrets/PII out of
+    logs and honors GRAFI_ERROR_INCLUDE_TRACEBACK (the key is absent when the
+    switch disables traceback capture), without forcing global Loguru config.
+    """
+    bound = logger.bind(
+        component_id=metadata.id,
+        component_name=metadata.name,
+        component_type=metadata.type,
+        conversation_id=getattr(invoke_context, "conversation_id", None),
+        invoke_id=getattr(invoke_context, "invoke_id", None),
+        assistant_request_id=getattr(invoke_context, "assistant_request_id", None),
+    )
+    component_label = metadata.type or "component"
+    summary = (
+        f"{component_label} '{metadata.name}' failed: "
+        f"{type(exc).__name__}: {error_message(exc)}"
+    )
+
+    already_logged = _traceback_already_logged(exc)
+    # Mark this exception (including re-wrapped outer ones) so the next decorator
+    # layer finds the flag within one link of the chain regardless of nesting
+    # depth, keeping the full traceback to a single emission.
+    try:
+        setattr(exc, _TRACEBACK_LOGGED_ATTR, True)
+    except Exception:  # pragma: no cover - builtins generally allow attributes
+        pass
+
+    traceback_str = error_details.get("traceback")
+    # Pass values as arguments so any braces in them are not re-interpreted as
+    # Loguru format placeholders.
+    if already_logged or not traceback_str:
+        bound.error("{}", summary)
+    else:
+        bound.error("{}\n{}", summary, traceback_str)
 
 
 def create_async_decorator(config: ComponentConfig) -> Callable:
@@ -136,10 +258,20 @@ def create_async_decorator(config: ComponentConfig) -> Callable:
                     )
 
             except Exception as e:
-                # Record failed event
-                if "span" in locals():
-                    span.set_attribute("error", str(e))
+                # Build structured details once, while the traceback is still
+                # attached to the exception.
+                error_details = _build_error_details(e, metadata)
 
+                # Enrich the active span with structured error information.
+                if "span" in locals():
+                    _record_span_error(span, e, error_details)
+
+                # Log a full traceback once at the layer closest to the failure;
+                # outer layers log a concise summary (see _log_component_exception).
+                _log_component_exception(e, metadata, invoke_context, error_details)
+
+                # Record failed event with both the human-readable string (kept
+                # for backward compatibility) and the structured details.
                 failed_event = config.event_types["failed"](
                     id=metadata.id,
                     name=metadata.name,
@@ -147,6 +279,7 @@ def create_async_decorator(config: ComponentConfig) -> Callable:
                     input_data=input_data,
                     invoke_context=invoke_context,
                     error=str(e),
+                    error_details=error_details,
                 )
                 await container.event_store.record_event(failed_event)
                 raise

--- a/grafi/common/events/component_base.py
+++ b/grafi/common/events/component_base.py
@@ -131,14 +131,20 @@ class FailedEvent(ComponentEvent, Generic[T_Input], ABC):
 
     input_data: T_Input
     error: Any
+    error_details: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "input_data": self._serialize_input(self.input_data),
+            "error": str(self.error),
+        }
+        # Additive, backward-compatible: only present when structured details
+        # were captured, so existing stored events and tests keep a stable shape.
+        if self.error_details is not None:
+            data["error_details"] = self.error_details
         return {
             **self.to_dict_base(),
-            "data": {
-                "input_data": self._serialize_input(self.input_data),
-                "error": str(self.error),
-            },
+            "data": data,
         }
 
     @abstractmethod
@@ -311,6 +317,7 @@ def create_component_events(
                 type=event_context["type"],
                 input_data=cls._deserialize_input(data["data"]["input_data"]),
                 error=data["data"]["error"],
+                error_details=data["data"].get("error_details"),
                 **{
                     k: v
                     for k, v in event_context.items()

--- a/grafi/common/exceptions/serialization.py
+++ b/grafi/common/exceptions/serialization.py
@@ -1,0 +1,170 @@
+"""Structured serialization of exceptions.
+
+Turns an exception (and its cause chain) into a JSON-serializable dict so that
+failed events, trace spans, and logs can expose the exception type, the module
+it came from, the full cause chain, domain-specific component fields, and the
+formatted traceback -- instead of only ``str(e)``.
+"""
+
+import traceback as traceback_module
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Optional
+
+from pydantic_core import to_jsonable_python
+
+from grafi.common.exceptions.base import GrafiError
+
+
+# Domain-specific attributes set by Grafi exception subclasses that help pinpoint
+# which component failed. Captured only when present on the exception instance.
+_DOMAIN_FIELDS = (
+    "node_name",
+    "tool_name",
+    "model",
+    "function_name",
+    "operation",
+    "topic_name",
+)
+
+# Bound the cause chain so a pathological or self-referential chain cannot loop
+# forever or bloat a persisted event.
+DEFAULT_MAX_CAUSE_DEPTH = 10
+
+
+def error_message(exc: BaseException) -> str:
+    """Return the human-readable message for an exception.
+
+    For :class:`GrafiError` this is the raw ``message`` (without the severity and
+    cause decoration that ``__str__`` adds); for any other exception it is
+    ``str(exc)``.
+    """
+    if isinstance(exc, GrafiError):
+        return exc.message
+    return str(exc)
+
+
+def _next_cause(exc: BaseException) -> Optional[BaseException]:
+    """Return the next exception in the chain.
+
+    Prefers :class:`GrafiError`'s explicit ``cause`` attribute, then the standard
+    ``__cause__`` (set by ``raise ... from``), then the implicit ``__context__``
+    unless it was suppressed.
+    """
+    grafi_cause = getattr(exc, "cause", None)
+    if isinstance(grafi_cause, BaseException):
+        return grafi_cause
+    if exc.__cause__ is not None:
+        return exc.__cause__
+    if not exc.__suppress_context__ and exc.__context__ is not None:
+        return exc.__context__
+    return None
+
+
+def iter_cause_chain(
+    exc: BaseException, *, max_depth: int = DEFAULT_MAX_CAUSE_DEPTH
+) -> Iterator[BaseException]:
+    """Yield ``exc`` and each exception in its cause chain, outermost first.
+
+    Bounded by ``max_depth`` and guarded against cycles.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and len(seen) < max_depth:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        yield current
+        current = _next_cause(current)
+
+
+def _summarize(exc: BaseException) -> Dict[str, Any]:
+    """Summarize a single exception (no traceback, no nested cause)."""
+    details: Dict[str, Any] = {
+        "error_type": type(exc).__name__,
+        "error_module": type(exc).__module__,
+        "message": error_message(exc),
+    }
+
+    if isinstance(exc, GrafiError):
+        details["severity"] = exc.severity
+        details["timestamp"] = exc.timestamp
+        if exc.invoke_context is not None:
+            # invoke_context.kwargs is a free-form Dict[str, Any] whose values
+            # are NOT coerced by model_dump(); force them to JSON-safe primitives
+            # so the persisted failed event can always be serialized (JSONB).
+            details["invoke_context"] = to_jsonable_python(
+                exc.invoke_context.model_dump(), serialize_unknown=True
+            )
+
+    for field in _DOMAIN_FIELDS:
+        value = getattr(exc, field, None)
+        if value is not None:
+            details[field] = to_jsonable_python(value, serialize_unknown=True)
+
+    return details
+
+
+def flatten_error_chain(
+    exc: BaseException, *, max_depth: int = DEFAULT_MAX_CAUSE_DEPTH
+) -> List[Dict[str, Any]]:
+    """Flatten the cause chain into a bounded list of summaries (outermost first)."""
+    return [_summarize(link) for link in iter_cause_chain(exc, max_depth=max_depth)]
+
+
+def _summarize_chain(
+    exc: BaseException, *, max_depth: int = DEFAULT_MAX_CAUSE_DEPTH
+) -> Dict[str, Any]:
+    """Summarize ``exc`` with a bounded, cycle-safe nested ``cause`` per link.
+
+    The result is ``_summarize(exc)`` plus a ``cause`` key holding the same nested
+    structure for the next exception in the chain, and so on. The deepest entry
+    (root cause) is the innermost ``cause``.
+    """
+    root: Optional[Dict[str, Any]] = None
+    parent: Optional[Dict[str, Any]] = None
+    for link in iter_cause_chain(exc, max_depth=max_depth):
+        summary = _summarize(link)
+        if parent is None:
+            root = summary
+        else:
+            parent["cause"] = summary
+        parent = summary
+    # iter_cause_chain always yields at least ``exc`` itself, so root is set.
+    return root if root is not None else _summarize(exc)
+
+
+def error_to_dict(
+    exc: BaseException,
+    *,
+    include_traceback: bool = True,
+    max_traceback_frames: Optional[int] = None,
+    max_cause_depth: int = DEFAULT_MAX_CAUSE_DEPTH,
+) -> Dict[str, Any]:
+    """Serialize an exception and its cause chain into a structured dict.
+
+    The outermost exception's fields are at the top level; the chain of underlying
+    causes is exposed as a nested ``cause`` object (each link itself may carry a
+    ``cause``), so the root cause is the innermost ``cause``.
+
+    Args:
+        exc: The exception to serialize.
+        include_traceback: When True (and a traceback is attached), include the
+            formatted, chained traceback under the ``traceback`` key.
+        max_traceback_frames: Optional frame limit forwarded to the stdlib
+            ``traceback`` module. Follows stdlib semantics: a positive N keeps the
+            first (oldest) N frames, a negative N keeps the last (innermost) ``|N|``
+            frames, ``0`` keeps none, and ``None`` (default) keeps every frame.
+        max_cause_depth: Upper bound on how many links of the cause chain to walk.
+    """
+    details = _summarize_chain(exc, max_depth=max_cause_depth)
+
+    if include_traceback and exc.__traceback__ is not None:
+        formatted = traceback_module.format_exception(
+            type(exc), exc, exc.__traceback__, limit=max_traceback_frames
+        )
+        details["traceback"] = "".join(formatted)
+
+    return details

--- a/grafi/tools/llms/impl/claude_tool.py
+++ b/grafi/tools/llms/impl/claude_tool.py
@@ -50,7 +50,7 @@ class ClaudeTool(LLM):
         default_factory=lambda: os.getenv("ANTHROPIC_API_KEY")
     )
     max_tokens: int = Field(default=4096)
-    model: str = Field(default="claude-3-5-haiku-20241022")  # or haiku, opus…
+    model: str = Field(default="claude-haiku-4-5-20251001")  # or haiku, opus…
 
     @classmethod
     def builder(cls) -> "ClaudeToolBuilder":
@@ -203,7 +203,7 @@ class ClaudeTool(LLM):
             .is_streaming(data.get("is_streaming", False))
             .system_message(data.get("system_message", ""))
             .api_key(os.getenv("ANTHROPIC_API_KEY"))
-            .model(data.get("model", "claude-3-5-haiku-20241022"))
+            .model(data.get("model", "claude-haiku-4-5-20251001"))
             .max_tokens(data.get("max_tokens", 4096))
             .build()
         )

--- a/tests/common/decorators/test_record_decorators.py
+++ b/tests/common/decorators/test_record_decorators.py
@@ -1,7 +1,43 @@
 """Tests for the unified record decorators."""
 
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_core import to_jsonable_python
+
+from grafi.common.containers.container import container
+from grafi.common.decorators.record_base import _TRACEBACK_LOGGED_ATTR
 from grafi.common.decorators.record_base import EventContext
+from grafi.common.decorators.record_base import _traceback_already_logged
 from grafi.common.decorators.record_decorators import record_tool_invoke
+from grafi.common.event_stores import EventStoreInMemory
+from grafi.common.events.component_events import ToolFailedEvent
+from grafi.common.exceptions.tool_exceptions import FunctionCallException
+from grafi.common.exceptions.workflow_exceptions import NodeExecutionError
+from grafi.common.models.invoke_context import InvokeContext
+from grafi.common.models.message import Message
+
+
+@pytest.fixture
+def isolated_container():
+    """Register an isolated in-memory store and a no-op tracer, then restore.
+
+    Using a mock tracer avoids the live ``setup_tracing`` path (a socket probe to
+    localhost:4317 and possible global instrumentation side effects). The previous
+    container state is restored so the global singleton does not leak across tests.
+    """
+    prev_store = container._event_store
+    prev_tracer = container._tracer
+    store = EventStoreInMemory()
+    container.register_event_store(store)
+    container.register_tracer(MagicMock())
+    try:
+        yield store
+    finally:
+        container._event_store = prev_store
+        container._tracer = prev_tracer
 
 
 class TestEventContext:
@@ -83,3 +119,93 @@ class TestDecoratorBehavior:
         assert decorated_async_func is not original_async_func
         assert callable(decorated_async_func)
         # Don't make assumptions about whether it preserves async nature
+
+
+class _ExplodingTool:
+    """Minimal tool-shaped object whose decorated invoke always raises."""
+
+    tool_id = "exploding-tool-id"
+    name = "ExplodingTool"
+    type = "FunctionCallTool"
+    oi_span_type = SimpleNamespace(value="TOOL")
+
+    @record_tool_invoke
+    async def invoke(self, invoke_context, input_data):
+        raise FunctionCallException(
+            tool_name="ExplodingTool",
+            function_name="detonate",
+            message="function call blew up",
+            invoke_context=invoke_context,
+            cause=ValueError("root boom"),
+        )
+        yield  # pragma: no cover - makes this an async generator
+
+
+class TestFailedEventErrorDetails:
+    """The decorator records structured error details and re-raises."""
+
+    @pytest.mark.asyncio
+    async def test_failed_event_carries_error_details(self, isolated_container):
+        event_store = isolated_container
+
+        tool = _ExplodingTool()
+        invoke_context = InvokeContext(
+            conversation_id="conversation_id",
+            invoke_id="invoke_id",
+            assistant_request_id="assistant_request_id",
+        )
+        messages = [Message(role="user", content="hi")]
+
+        # The original exception still propagates unchanged.
+        with pytest.raises(FunctionCallException) as exc_info:
+            async for _ in tool.invoke(invoke_context, messages):
+                pass
+        assert exc_info.value.function_name == "detonate"
+
+        events = await event_store.get_events()
+        failed = [e for e in events if isinstance(e, ToolFailedEvent)]
+        assert len(failed) == 1
+
+        details = failed[0].error_details
+        assert details is not None
+        assert details["error_type"] == "FunctionCallException"
+        assert details["message"] == "function call blew up"
+        assert details["component_name"] == "ExplodingTool"
+        assert details["component_type"] == "FunctionCallTool"
+        assert details["tool_name"] == "ExplodingTool"
+        assert details["function_name"] == "detonate"
+        assert details["cause"]["error_type"] == "ValueError"
+
+        # A real traceback was captured pointing at the failure site.
+        assert details["traceback"]
+        assert "detonate" in details["traceback"] or "invoke" in details["traceback"]
+
+        # The persisted payload must be JSON-serializable (JSONB storage).
+        json.dumps(details, default=to_jsonable_python)
+
+        # Human-readable string still recorded for backward compatibility.
+        assert failed[0].error
+
+
+class TestTracebackDedup:
+    """The full traceback is logged once even after the error is re-wrapped."""
+
+    def test_flag_survives_rewrapping(self):
+        inner = ValueError("root boom")
+        # The innermost decorator marks the exception it caught.
+        setattr(inner, _TRACEBACK_LOGGED_ATTR, True)
+
+        # The workflow re-wraps it into a new exception with cause=inner.
+        outer = NodeExecutionError(
+            node_name="SearchNode", message="node failed", cause=inner
+        )
+
+        # An outer decorator must still see that the traceback was already logged.
+        assert _traceback_already_logged(outer) is True
+
+    def test_fresh_chain_not_yet_logged(self):
+        inner = ValueError("root boom")
+        outer = NodeExecutionError(
+            node_name="SearchNode", message="node failed", cause=inner
+        )
+        assert _traceback_already_logged(outer) is False

--- a/tests/common/exceptions/test_serialization.py
+++ b/tests/common/exceptions/test_serialization.py
@@ -1,0 +1,166 @@
+"""Tests for grafi.common.exceptions.serialization."""
+
+import json
+
+from grafi.common.exceptions.base import GrafiError
+from grafi.common.exceptions.serialization import error_message
+from grafi.common.exceptions.serialization import error_to_dict
+from grafi.common.exceptions.serialization import flatten_error_chain
+from grafi.common.exceptions.serialization import iter_cause_chain
+from grafi.common.exceptions.tool_exceptions import FunctionCallException
+from grafi.common.exceptions.tool_exceptions import LLMToolException
+from grafi.common.exceptions.workflow_exceptions import NodeExecutionError
+from grafi.common.models.invoke_context import InvokeContext
+
+
+def _raise_and_capture(exc: BaseException) -> BaseException:
+    """Raise and catch so the exception gets a real ``__traceback__``."""
+    try:
+        raise exc
+    except BaseException as caught:  # noqa: BLE001
+        return caught
+
+
+def test_generic_exception_with_traceback() -> None:
+    err = _raise_and_capture(ValueError("boom"))
+    details = error_to_dict(err)
+
+    assert details["error_type"] == "ValueError"
+    assert details["error_module"] == "builtins"
+    assert details["message"] == "boom"
+    assert "boom" in details["traceback"]
+    assert "ValueError" in details["traceback"]
+    # No cause -> no nested cause key.
+    assert "cause" not in details
+
+
+def test_traceback_can_be_disabled() -> None:
+    err = _raise_and_capture(ValueError("boom"))
+    details = error_to_dict(err, include_traceback=False)
+    assert "traceback" not in details
+
+
+def test_grafi_error_includes_invoke_context_and_severity() -> None:
+    ctx = InvokeContext(conversation_id="c", invoke_id="i", assistant_request_id="a")
+    err = GrafiError("kaboom", invoke_context=ctx, severity="CRITICAL")
+    details = error_to_dict(err, include_traceback=False)
+
+    assert details["error_type"] == "GrafiError"
+    assert details["error_module"] == "grafi.common.exceptions.base"
+    assert details["message"] == "kaboom"
+    assert details["severity"] == "CRITICAL"
+    assert details["invoke_context"]["conversation_id"] == "c"
+
+
+def test_node_execution_error_with_function_call_cause() -> None:
+    root = ValueError("root cause")
+    fc = FunctionCallException(
+        tool_name="search_tool",
+        function_name="do_search",
+        message="function call failed",
+        cause=root,
+    )
+    node_err = NodeExecutionError(
+        node_name="SearchNode", message="node failed", cause=fc
+    )
+    details = error_to_dict(node_err, include_traceback=False)
+
+    assert details["error_type"] == "NodeExecutionError"
+    assert details["node_name"] == "SearchNode"
+
+    # Immediate cause (nested).
+    assert details["cause"]["error_type"] == "FunctionCallException"
+    assert details["cause"]["tool_name"] == "search_tool"
+    assert details["cause"]["function_name"] == "do_search"
+
+    # Root cause is the innermost nested cause.
+    assert details["cause"]["cause"]["error_type"] == "ValueError"
+    assert details["cause"]["cause"]["message"] == "root cause"
+    assert "cause" not in details["cause"]["cause"]
+
+
+def test_llm_tool_exception_includes_tool_name_and_model() -> None:
+    err = LLMToolException(
+        tool_name="openai_tool", model="gpt-4o", message="llm failed"
+    )
+    details = error_to_dict(err, include_traceback=False)
+
+    assert details["tool_name"] == "openai_tool"
+    assert details["model"] == "gpt-4o"
+
+
+def test_function_call_exception_includes_function_name() -> None:
+    err = FunctionCallException(
+        tool_name="search_tool", function_name="do_search", message="failed"
+    )
+    details = error_to_dict(err, include_traceback=False)
+
+    assert details["tool_name"] == "search_tool"
+    assert details["function_name"] == "do_search"
+
+
+def test_flatten_error_chain_is_cycle_safe() -> None:
+    a = GrafiError("a")
+    b = GrafiError("b", cause=a)
+    a.cause = b  # introduce a cycle
+
+    chain = flatten_error_chain(a)
+
+    # The cycle guard yields each distinct exception exactly once.
+    assert len(chain) == 2
+    assert chain[0]["message"] == "a"
+    assert chain[1]["message"] == "b"
+
+
+def test_flatten_error_chain_is_depth_bounded() -> None:
+    deepest = GrafiError("level-0")
+    current = deepest
+    for level in range(1, 30):
+        current = GrafiError(f"level-{level}", cause=current)
+
+    chain = flatten_error_chain(current)
+    assert len(chain) == 10  # DEFAULT_MAX_CAUSE_DEPTH
+    # Walk is outermost-first; the deeper tail is truncated.
+    assert chain[0]["message"] == "level-29"
+    assert chain[-1]["message"] == "level-20"
+
+
+def test_error_message_prefers_grafi_message() -> None:
+    err = GrafiError("clean message", severity="ERROR")
+    # str(err) adds decoration; error_message returns the raw message.
+    assert error_message(err) == "clean message"
+    assert "clean message" in str(err)
+    assert error_message(ValueError("plain")) == "plain"
+
+
+def test_error_to_dict_is_json_safe_with_exotic_invoke_context_kwargs() -> None:
+    class _Weird:
+        def __repr__(self) -> str:
+            return "<weird-object>"
+
+    ctx = InvokeContext(
+        conversation_id="c",
+        invoke_id="i",
+        assistant_request_id="a",
+        kwargs={"obj": _Weird()},
+    )
+    err = GrafiError("boom", invoke_context=ctx)
+    details = error_to_dict(err, include_traceback=False)
+
+    # The whole payload must be JSON-serializable for JSONB persistence.
+    json.dumps(details)
+    # The non-serializable object is rendered to a string, not dropped.
+    assert isinstance(details["invoke_context"]["kwargs"]["obj"], str)
+
+
+def test_iter_cause_chain_yields_outermost_first_and_is_cycle_safe() -> None:
+    root = ValueError("root")
+    middle = GrafiError("middle", cause=root)
+    outer = GrafiError("outer", cause=middle)
+
+    chain = list(iter_cause_chain(outer))
+    assert chain == [outer, middle, root]
+
+    # Cycle: outer -> middle -> outer
+    middle.cause = outer
+    assert list(iter_cause_chain(outer)) == [outer, middle]

--- a/tests/events/tool_events/test_tool_failed_event.py
+++ b/tests/events/tool_events/test_tool_failed_event.py
@@ -79,9 +79,46 @@ def tool_failed_event_dict():
     }
 
 
+@pytest.fixture
+def tool_failed_event_with_details(tool_failed_event) -> Any:
+    return tool_failed_event.model_copy(
+        update={
+            "error_details": {
+                "error_type": "FunctionCallException",
+                "error_module": "grafi.common.exceptions.tool_exceptions",
+                "message": "function call blew up",
+                "tool_name": "test_tool",
+                "cause": {"error_type": "ValueError", "message": "root boom"},
+                "traceback": "Traceback (most recent call last): ...",
+            }
+        }
+    )
+
+
 def test_tool_failed_event_to_dict(tool_failed_event, tool_failed_event_dict):
     assert tool_failed_event.to_dict() == tool_failed_event_dict
 
 
 def test_tool_failed_event_from_dict(tool_failed_event_dict, tool_failed_event):
     assert ToolFailedEvent.from_dict(tool_failed_event_dict) == tool_failed_event
+
+
+def test_tool_failed_event_omits_error_details_when_absent(tool_failed_event):
+    # Backward compatibility: with no structured details, the key is absent and
+    # the serialized shape is unchanged.
+    assert "error_details" not in tool_failed_event.to_dict()["data"]
+
+
+def test_tool_failed_event_to_dict_includes_error_details(
+    tool_failed_event_with_details,
+):
+    data = tool_failed_event_with_details.to_dict()["data"]
+    assert data["error"] == "error"  # human-readable string preserved
+    assert data["error_details"]["error_type"] == "FunctionCallException"
+    assert data["error_details"]["cause"]["error_type"] == "ValueError"
+
+
+def test_tool_failed_event_error_details_round_trip(tool_failed_event_with_details):
+    restored = ToolFailedEvent.from_dict(tool_failed_event_with_details.to_dict())
+    assert restored == tool_failed_event_with_details
+    assert restored.error_details["cause"]["message"] == "root boom"

--- a/tests/tools/llms/test_claude_tool.py
+++ b/tests/tools/llms/test_claude_tool.py
@@ -33,7 +33,7 @@ def claude_instance() -> ClaudeTool:
         system_message="dummy system message",
         name="ClaudeTool",
         api_key="test_api_key",
-        model="claude-3-5-haiku-20241022",
+        model="claude-haiku-4-5-20251001",
         max_tokens=2048,
     )
 
@@ -43,7 +43,7 @@ def claude_instance() -> ClaudeTool:
 # --------------------------------------------------------------------------- #
 def test_init(claude_instance):
     assert claude_instance.api_key == "test_api_key"
-    assert claude_instance.model == "claude-3-5-haiku-20241022"
+    assert claude_instance.model == "claude-haiku-4-5-20251001"
     assert claude_instance.system_message == "dummy system message"
     assert claude_instance.max_tokens == 2048
 
@@ -93,7 +93,7 @@ async def test_invoke_simple_response(monkeypatch, claude_instance, invoke_conte
 
     # verify create() called with right kwargs
     kwargs = mock_client.messages.create.call_args[1]
-    assert kwargs["model"] == "claude-3-5-haiku-20241022"
+    assert kwargs["model"] == "claude-haiku-4-5-20251001"
     assert kwargs["max_tokens"] == 2048
     assert kwargs["messages"][0] == {
         "role": "system",
@@ -214,7 +214,7 @@ def test_to_dict(claude_instance):
     assert d["name"] == "ClaudeTool"
     assert d["type"] == "ClaudeTool"
     assert d["api_key"] == "****************"
-    assert d["model"] == "claude-3-5-haiku-20241022"
+    assert d["model"] == "claude-haiku-4-5-20251001"
 
 
 # --------------------------------------------------------------------------- #
@@ -230,7 +230,7 @@ async def test_from_dict():
         "type": "ClaudeTool",
         "oi_span_type": "LLM",
         "system_message": "You are helpful",
-        "model": "claude-3-5-haiku-20241022",
+        "model": "claude-haiku-4-5-20251001",
         "max_tokens": 2048,
         "chat_params": {"temperature": 0.7},
         "is_streaming": False,
@@ -241,7 +241,7 @@ async def test_from_dict():
 
     assert isinstance(tool, ClaudeTool)
     assert tool.name == "TestClaude"
-    assert tool.model == "claude-3-5-haiku-20241022"
+    assert tool.model == "claude-haiku-4-5-20251001"
     assert tool.max_tokens == 2048
     assert tool.system_message == "You are helpful"
     assert tool.chat_params == {"temperature": 0.7}

--- a/tests/tools/test_tool_factory.py
+++ b/tests/tools/test_tool_factory.py
@@ -53,7 +53,7 @@ async def test_tool_factory_claude_tool():
         "type": "ClaudeTool",
         "oi_span_type": "LLM",
         "system_message": "You are helpful",
-        "model": "claude-3-5-haiku-20241022",
+        "model": "claude-haiku-4-5-20251001",
         "max_tokens": 4096,
         "chat_params": {},
         "is_streaming": False,
@@ -64,7 +64,7 @@ async def test_tool_factory_claude_tool():
 
     assert isinstance(tool, ClaudeTool)
     assert tool.name == "ClaudeTool"
-    assert tool.model == "claude-3-5-haiku-20241022"
+    assert tool.model == "claude-haiku-4-5-20251001"
     assert tool.max_tokens == 4096
 
 
@@ -273,7 +273,7 @@ async def test_tool_factory_roundtrip_claude():
     original = (
         ClaudeTool.builder()
         .name("test_claude")
-        .model("claude-3-5-haiku-20241022")
+        .model("claude-haiku-4-5-20251001")
         .max_tokens(2048)
         .system_message("You are helpful")
         .build()

--- a/tests_integration/function_call_assistant/simple_claude_function_call_assistant.py
+++ b/tests_integration/function_call_assistant/simple_claude_function_call_assistant.py
@@ -39,7 +39,7 @@ class SimpleClaudeFunctionCallAssistant(Assistant):
     name: str = Field(default="SimpleClaudeFunctionCallAssistant")
     type: str = Field(default="SimpleClaudeFunctionCallAssistant")
     api_key: str = Field(default_factory=lambda: os.getenv("ANTHROPIC_API_KEY", ""))
-    model: str = Field(default="claude-3-5-haiku-20241022")
+    model: str = Field(default="claude-haiku-4-5-20251001")
     function_call_llm_system_message: Optional[str] = Field(default=None)
     summary_llm_system_message: Optional[str] = Field(default=None)
     function_tool: FunctionCallTool


### PR DESCRIPTION
## Summary

Failed assistant/workflow/node/tool runs previously persisted only `str(e)` and logged no traceback, so a developer couldn't tell which component failed, why, or where. This PR (PR 1 of the [ENG-256 plan](docs/plans/ENG-256-logging-exception-handler-plan.md), included in the diff) surfaces the exception type, module, full cause chain, component location, and traceback — in both failed events and logs — without changing successful execution behavior.

## What changed

- **`grafi/common/exceptions/serialization.py`** (new) — `error_to_dict` / `flatten_error_chain` / `iter_cause_chain` / `error_message`. Builds a bounded, cycle-safe, **JSON-safe** structured dict (error type/module, message, severity, invoke context, domain fields like `node_name`/`tool_name`, a recursive nested `cause`, and the formatted traceback). `invoke_context.kwargs` is forced through `to_jsonable_python(serialize_unknown=True)` so a failed event can always persist to JSONB.
- **`grafi/common/events/component_base.py`** — `FailedEvent.error_details` (optional). Serialized into `data["error_details"]` **only when present**, so existing stored events and the exact-match failed-event tests stay stable; `from_dict` reads it via `.get()` for old data.
- **`grafi/common/decorators/record_base.py`** — the centralized async decorator's `except` block now builds `error_details`, enriches the OpenTelemetry span (`error.*` attributes + `record_exception` + `set_status`), and logs a **clean stdlib traceback string exactly once** at the layer closest to the failure. The dedup is cause-chain-aware, so it survives the re-wrapping that happens as the error propagates tool → node → workflow → assistant (no 4× stack dumps). Honors `GRAFI_ERROR_INCLUDE_TRACEBACK` and avoids leaking local-variable values into logs.

### Also included
- Bump deprecated `claude-3-5-haiku-20241022` → `claude-haiku-4-5-20251001` in `ClaudeTool` (field + `from_dict` defaults), the Claude function-call example, and the related tests.

## Backward compatibility
- Additive only: `error_details` is omitted when absent, so persisted event shape and the four existing failed-event round-trip tests are unchanged.
- Success/respond/invoke paths are untouched; the original exception is always re-raised.

## Testing
- Full unit suite green (**608 passing**); new tests cover the serialization helper (cause chain, cycle/depth bounds, JSON-safety), an end-to-end decorator test (asserts `error_details`, real traceback, JSON-serializability, and that the exception still propagates), cross-layer traceback dedup, and `error_details` round-trips.
- `ruff` clean; `serialization.py` + `component_base.py` mypy-clean (remaining `record_base.py` mypy notes are pre-existing, from the dynamically-generated factory event classes).
- Reviewed via an adversarial multi-agent pass; confirmed findings (JSON-safety, log privacy, dedup depth, test hygiene) were addressed.

## Follow-up (PR 2, scoped in the plan doc)
Extract a `logging_utils` helper, extend `GrafiError.to_dict()`, `raise ... from e` in `event_store._create_event_from_dict`, migrate the scattered `logger.error(f"... {e}")` calls, optional `configure_logging()`, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)