### PR TITLE
Bump version to 0.0.36 to trigger PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grafi"
-version = "0.0.35"
+version = "0.0.36"
 description = "Grafi - a flexible, event-driven framework that enables the creation of domain-specific AI agents through composable agentic workflows."
 authors = [{name = "Craig Li", email = "craig@binome.dev"}]
 license = {text = "Mozilla Public License Version 2.0"}


### PR DESCRIPTION
## Summary

Bumps the package version `0.0.35` → `0.0.36`. Merging this to `main` triggers the CI publish pipeline (PyPI publish + GitHub release/tag) since the version will differ from the one on PyPI.

## Changes released since 0.0.35
- #100 Refine LLM tools: modern API params
- #101 Replace container singleton with request-scoped runtime DI; simplify error logging
- #102 Bump dependencies to clear Dependabot security alerts

## Release mechanism
On merge to `main`, `.github/workflows/ci.yaml` runs the full test suite, then the `version` → `publish_pypi` → `github_release` jobs detect the version mismatch and publish automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)